### PR TITLE
build: exclude models (pojos) from coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,12 @@
     <jacoco.codeCoverage.minRatio>0.20</jacoco.codeCoverage.minRatio>
     <groovy.version>3.0.7</groovy.version> <!-- temp fix for inconsistent use of API in REST Assured -->
 
+    <trebol.coverage-exclusions>**/trebol/api/models/**.*</trebol.coverage-exclusions>
+
     <!-- Sonar CI/CD -->
     <sonar.organization>trebol-ecommerce</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+    <sonar.coverage.exclusions>${trebol.coverage-exclusions}</sonar.coverage.exclusions>
   </properties>
 
   <dependencies>
@@ -277,6 +280,7 @@
               <goal>check</goal>
             </goals>
             <configuration>
+              <excludes>${trebol.coverage-exclusions}</excludes>
               <rules>
                 <rule>
                   <element>BUNDLE</element>


### PR DESCRIPTION
## PR Checklist

- [x] Read the [contribution guidelines](/CONTRIBUTING.md)
- [ ] Added a brief description of these changes to the top of the [changelog](/CHANGELOG.md)
- [x] Changes in code meet test criteria (running `mvn test` returns exit code 0, without errors)

## PR Type

- [x] Build-related

## Summary

Exclude all model (POJO) classes from code coverage analysis. I found no reason to create tests for these, since these benefit the most from lombok's code generation features than any other classes. To cover them, we'd have to write very repetitive, counter-intuitive, unmaintainable testing code.