### PR TITLE
Bump spring to 2.7.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ Java version | Supported?
 16           | ✅ yes
 17           | ✅ yes
 18           | ✅ yes
-19           | 🔴 no
-20           | 🔴 no
+19           | ✅ no
+20           | ✅ no
 21           | 🔴 no
 
 ### Requirements

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.12</version>
+    <version>2.7.16</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.trebolecommerce</groupId>


### PR DESCRIPTION
## PR Checklist

- [ ] Read the [contribution guidelines](/CONTRIBUTING.md)
- [ ] Added a brief description of these changes to the top of the [changelog](/CHANGELOG.md)
- [ ] Changes in code meet test criteria (running `mvn test` returns exit code 0, without errors)

## PR Type
- [ ] Bugfix
- [ ] Feature
- [ ] Code style (code formatting, local variable naming)
- [ ] Refactoring (changes that do not affect API nor functionality)
- [x] Build-related
- [x] Documentation
- [ ] Test-related

## Summary
Bumping Spring Boot from `2.6.12` to `2.7.16` adds support for JDK 19 and 20.
Closes: #261
